### PR TITLE
Gem cache directory bug fix

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -172,7 +172,7 @@ function addFiletoZip(zip, dir_path, file_name){
   return fs.statAsync(filePath)
           .then(stat => {
             if (stat.isDirectory()){
-              if (new RegExp('ruby/.*/cache$').test(filePath)){
+              if (new RegExp('ruby/[^/]*/cache$').test(filePath)){
                 return undefined;
               }
               return addDirtoZip(zip.folder(file_name), filePath);


### PR DESCRIPTION
This tweaks a regex so that we're more selective about which `cache` directories are excluded from `gemLayer.zip`. I think we want to exclude only the ruby cache directories like `ruby/2.7.0/cache/`. This fix will allow directories like `ruby/2.7.0/gems/activesupport-6.1.4/lib/active_support/cache/` to be present in the zip file.

Fixes #56