### PR TITLE
Speed up Docker based builds by installing gems as a Docker layer

### DIFF
--- a/docs/usage_examples/use_docker_file.md
+++ b/docs/usage_examples/use_docker_file.md
@@ -34,6 +34,13 @@ FROM lambci/lambda:build-ruby2.5
 RUN yum install -y postgresql-devel
 RUN gem update bundler
 
+RUN bundle config set --local path build
+RUN bundle config set --local without test development
+
+COPY Gemfile* .
+
+RUN bundle install
+
 CMD "/bin/bash"
 ```
 

--- a/docs/usage_examples/use_docker_file_with_build_args.md
+++ b/docs/usage_examples/use_docker_file_with_build_args.md
@@ -44,6 +44,13 @@ RUN echo "a dummy file that we generate every time" > ./test_arg_dummy
 
 RUN if [[ -z "$SERVERLESS_RUBY_LAYER_TEST_ARG" ]] ; then echo "Argument not provided" ; else echo "Argument is $SERVERLESS_RUBY_LAYER_TEST_ARG"; echo "Argument is $SERVERLESS_RUBY_LAYER_TEST_ARG" > ./test_arg_present ; fi
 
+RUN bundle config set --local path build
+RUN bundle config set --local without test development
+
+COPY Gemfile* .
+
+RUN bundle install
+
 CMD "/bin/bash"
 ```
 

--- a/examples/use-docker-file-with-build-args/Dockerfile
+++ b/examples/use-docker-file-with-build-args/Dockerfile
@@ -9,4 +9,15 @@ RUN echo "a dummy file that we generate every time" > ./test_arg_dummy
 
 RUN if [[ -z "$SERVERLESS_RUBY_LAYER_TEST_ARG" ]] ; then echo "Argument not provided" ; else echo "Argument is $SERVERLESS_RUBY_LAYER_TEST_ARG"; echo "Argument is $SERVERLESS_RUBY_LAYER_TEST_ARG" > ./test_arg_present ; fi
 
+RUN mkdir /var/gem_build
+
+WORKDIR /var/gem_build
+
+RUN bundle config set --local path build
+RUN bundle config set --local without test development
+
+COPY Gemfile* .
+
+RUN bundle install
+
 CMD "/bin/bash"

--- a/examples/use-docker-file-with-build-args/Dockerfile
+++ b/examples/use-docker-file-with-build-args/Dockerfile
@@ -9,10 +9,6 @@ RUN echo "a dummy file that we generate every time" > ./test_arg_dummy
 
 RUN if [[ -z "$SERVERLESS_RUBY_LAYER_TEST_ARG" ]] ; then echo "Argument not provided" ; else echo "Argument is $SERVERLESS_RUBY_LAYER_TEST_ARG"; echo "Argument is $SERVERLESS_RUBY_LAYER_TEST_ARG" > ./test_arg_present ; fi
 
-RUN mkdir /var/gem_build
-
-WORKDIR /var/gem_build
-
 RUN bundle config set --local path build
 RUN bundle config set --local without test development
 

--- a/examples/use-docker-file/Dockerfile
+++ b/examples/use-docker-file/Dockerfile
@@ -3,4 +3,15 @@ FROM lambci/lambda:build-ruby2.5
 RUN yum install -y postgresql-devel
 RUN gem update bundler
 
+RUN mkdir /var/gem_build
+
+WORKDIR /var/gem_build
+
+RUN bundle config set --local path build
+RUN bundle config set --local without test development
+
+COPY Gemfile* .
+
+RUN bundle install
+
 CMD "/bin/bash"

--- a/examples/use-docker-file/Dockerfile
+++ b/examples/use-docker-file/Dockerfile
@@ -3,10 +3,6 @@ FROM lambci/lambda:build-ruby2.5
 RUN yum install -y postgresql-devel
 RUN gem update bundler
 
-RUN mkdir /var/gem_build
-
-WORKDIR /var/gem_build
-
 RUN bundle config set --local path build
 RUN bundle config set --local without test development
 

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -60,7 +60,6 @@ function bundleInstall(){
     if (ps.error && ps.error.code === 'ENOENT') {
       throw new Error('docker command not found. Please install docker https://www.docker.com/products/docker-desktop');
     }
-    let buildDocker = false;
     if (this.options.docker_file) {
       const docker_file_path = path.join(this.servicePath, this.options.docker_file)
       if (!fs.pathExistsSync(docker_file_path)){
@@ -69,43 +68,63 @@ function bundleInstall(){
 
       fs.copySync(docker_file_path,
                   path.join(this.ruby_layer,'Dockerfile'))
-      buildDocker = true
-    }else if (this.options.docker_yums) {
+    }else{
       docker_steps =['FROM lambci/lambda:build-'+this.serverless.service.provider.runtime]
-      this.options.docker_yums.forEach(function(package_name) {
-        docker_steps.push('RUN yum install -y '+package_name)
-      })
-      docker_steps.push('RUN gem update bundler')
+      if (this.options.docker_yums) {
+        this.options.docker_yums.forEach(function(package_name) {
+          docker_steps.push('RUN yum install -y '+package_name)
+        })
+      }
       if(this.options.docker_env_variable){
         this.options.docker_env_variable.forEach(function(build_arg) {
           docker_steps.push('ARG ' + build_arg)
           docker_steps.push('ENV ' + build_arg + '=${' + build_arg + '}')
         })
       }
+
+      var bundlerVersionToInstall = ''
+      var bundlerNumericVersion = 2.1 // If a version is not specified we assume that we're using latest which is >= 2.1
+      if(this.use_gemfile_lock){
+        const data = fs.readFileSync(gem_file_lock_path).toString().match(/BUNDLED WITH[\r\n]+([^\r\n]+)/)
+        bundlerNumericVersion = data[data.length - 1].trim()
+        bundlerVersionToInstall = ':' + bundlerNumericVersion
+      }
+      docker_steps.push('RUN gem install bundler' + bundlerVersionToInstall)
+
+      docker_steps.push('COPY Gemfile* .')
+
+      if(bundlerNumericVersion >= 2.1){
+        docker_steps.push('RUN bundle config set --local path build')
+        docker_steps.push('RUN bundle config set --local without test development')
+        docker_steps.push('RUN bundle install')
+      }else{
+        docker_steps.push('RUN bundle install --path build --without test development')
+      }
+
       docker_steps.push('CMD "/bin/bash"')
       fs.writeFileSync(path.join(this.ruby_layer,'Dockerfile'),docker_steps.join('\n'))
-      buildDocker = true
     }
-    if (buildDocker) {
-      this.cli.log("Building docker for bundle install")
-      docker_name ='ruby-layer:docker'
-      docker_args = ['build', '-t', docker_name, '-f', 'Dockerfile']
-      if(this.options.docker_build_args){
-        this.options.docker_build_args.forEach(function(build_arg) {
-          docker_args.push('--build-arg')
-          docker_args.push(build_arg)
-        })
-      }
-      if(this.options.docker_env_variable){
-        this.options.docker_env_variable.forEach(function(build_arg) {
-          docker_args.push('--build-arg')
-          docker_args.push(build_arg)
-        })
-      }
-      docker_args.push('.')
-      docker(docker_args, options,this.cli)
+
+    this.cli.log("Building docker for bundle install")
+    docker_name ='ruby-layer:docker'
+    docker_args = ['build', '-t', docker_name, '-f', 'Dockerfile']
+    if(this.options.docker_build_args){
+      this.options.docker_build_args.forEach(function(build_arg) {
+        docker_args.push('--build-arg')
+        docker_args.push(build_arg)
+      })
     }
+    if(this.options.docker_env_variable){
+      this.options.docker_env_variable.forEach(function(build_arg) {
+        docker_args.push('--build-arg')
+        docker_args.push(build_arg)
+      })
+    }
+    docker_args.push('.')
+    docker(docker_args, options,this.cli)
+
     let docker_id = Date.now().toString(36)  + '-'+Math.random().toString(36).slice(2, 15)
+    this.cli.log("docker_id = ", docker_id)
     ps=docker(['run','-it','--name',docker_id,'-d', docker_name,'/bin/bash'], options,this.cli)
     container_id = ps.stdout.toString().trim()
     console.log(container_id)
@@ -117,26 +136,14 @@ function bundleInstall(){
         ps=docker(['cp','-L', container_id+':'+lib_to_copy, lib_path],options,this.cli)
       })
     }
-    this.cli.log("Installing gem using docker bundler")
-    this.docker_gem_path = '/var/gem_build'
-    docker(['exec', docker_id, 'mkdir', this.docker_gem_path], options, this.cli)
-    docker(['cp', '-L', 'Gemfile', container_id+':'+this.docker_gem_path], options,this.cli)
-    if (this.use_gemfile_lock){
-      docker(['cp', '-L', 'Gemfile.lock', container_id+':'+this.docker_gem_path], options,this.cli)
-      const data = fs.readFileSync(gem_file_lock_path).toString().match(/BUNDLED WITH[\r\n]+([^\r\n]+)/)
-      docker(['exec','-w',this.docker_gem_path, docker_id].concat(['gem','install','bundler:'+ data[data.length - 1].trim()]),options,this.cli)
-    }
-    ps = docker(['exec','-w',this.docker_gem_path, docker_id].concat(['bundle','-v']),options,this.cli)
-    bundle_args = setBundleConfig(ps.stdout.toString(),(args) =>{
-      docker(['exec','-w',this.docker_gem_path, docker_id, 'bundle','config', 'set', '--local'].concat(args), options, this.cli)
-    })
-    docker(['exec','-w',this.docker_gem_path, docker_id].concat(bundle_args),options,this.cli)
+    this.cli.log("Packaging gems from docker bundler")
+    this.docker_gem_path = '/var/task'
     docker(['cp', '-L', container_id+':'+this.docker_gem_path+'/build/ruby', this.build_path], options, this.cli)
     docker(['stop', container_id], options, this.cli)
     docker(['rm',docker_id], options, this.cli)
   } else {
     ps = runCommand("bundle",['-v'], options, this.cli)
-     bundle_version = ps.stdout.toString()
+    bundle_version = ps.stdout.toString()
     if (ps.error && ps.error.code === 'ENOENT') {
        throw new Error('bundle command not found in local. Please install ruby. https://www.ruby-lang.org/en/downloads/');
     }
@@ -290,6 +297,6 @@ function bundleGems()  {
           .then(bundleInstall)
           .then(zipBundleFolder)
           .then(configureLayer)
-} 
+}
 
 module.exports = { bundleGems, excludePackage };


### PR DESCRIPTION
This PR implements the proposal from #58.

In my local test project this takes about 90 seconds off of the time for a full `sls deploy` (after the first deploy, and when the `Gemfile` and `Gemfile.lock` hasn't changed).

For apps that are already using a `Dockerfile` this will introduce a breaking change that will require updates to the `Dockerfile`.

A file that looked like this before:
```Dockerfile
FROM lambci/lambda:build-ruby2.5

RUN yum install -y postgresql-devel
RUN gem update bundler

CMD "/bin/bash"
```

Will need to be updated to look like this:
```Dockerfile
FROM lambci/lambda:build-ruby2.5

RUN yum install -y postgresql-devel
RUN gem update bundler

# Begin new stuff
RUN bundle config set --local path build
RUN bundle config set --local without test development

COPY Gemfile* .

RUN bundle install
# End new stuff

CMD "/bin/bash"
```