### PR TITLE
add support for native binaries and directories

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,8 @@ custom:
     use_docker: true
     docker_yums:
       - postgresql-devel
+    natvie_bins:
+      - /usr/bin/psql
     native_libs:
       - /usr/lib64/libpq.so.5
     environment:
@@ -23,6 +25,7 @@ custom:
 | -------------   |-------- |-------------- | --------------------|
 | **use_docker**  | boolean | false         | Set true to use Docker to bundle gems with OS native C extensions or system libraries |
 | **docker_yums** | array   | undefined     | List of yum libraries to be preinstalled for gems which require OS native system libraries |
+| **native_bins** | array   | undefined     | Paths of the native executable files that need to be packed in lambda layer along with gems |
 | **native_libs** | array   | undefined     | Paths of the native libraries files that need to be packed in lambda layer along with gems |
 | **docker_file** | string  | undefined     | Path of the custom docker file to be used for bundling gems|
 | **include_functions** | array | all functions  | List of functions to be configured with the gem layer |

--- a/docs/usage_examples/use_docker_file.md
+++ b/docs/usage_examples/use_docker_file.md
@@ -16,6 +16,8 @@ custom:
   rubyLayer:
     use_docker: true
     docker_file: Dockerfile
+    native_bins:
+      - /usr/bin/pdfinfo
     native_libs:
       - /usr/lib64/libpq.so.5
       - /usr/lib64/libldap_r-2.4.so.2

--- a/docs/usage_examples/use_docker_with_yums.md
+++ b/docs/usage_examples/use_docker_with_yums.md
@@ -19,6 +19,8 @@ custom:
     use_docker: true
     docker_yums:
       - postgresql-devel
+    native_bins:
+      - /usr/bin/psql
     native_libs:
       - /usr/lib64/libpq.so.5
       - /usr/lib64/libldap_r-2.4.so.2

--- a/examples/use-docker-file/serverless.yml
+++ b/examples/use-docker-file/serverless.yml
@@ -7,6 +7,8 @@ custom:
   rubyLayer:
     use_docker: true
     docker_file: Dockerfile
+    native_bins:
+      - /usr/bin/psql
     native_libs:
       - /usr/lib64/libpq.so.5
       - /usr/lib64/libldap_r-2.4.so.2
@@ -23,4 +25,3 @@ provider:
 functions:
   hello:
     handler: handler.hello
-

--- a/examples/use-docker-with-yums-pg-old/serverless.yml
+++ b/examples/use-docker-with-yums-pg-old/serverless.yml
@@ -8,6 +8,8 @@ custom:
     use_docker: true
     docker_yums:
       - postgresql-devel
+    native_bins:
+      - /usr/bin/psql
     native_libs:
       - /usr/lib64/libpq.so.5
       - /usr/lib64/libldap_r-2.4.so.2

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -7,6 +7,9 @@ var JSZip = require('jszip');
 Promise.promisifyAll(fs);
 
 function runCommand(cmd,args,options,cli) {
+  if (process.env.SLS_DEBUG){
+    cli.log(cmd, args, options)
+  }
   const ps = spawnSync(cmd, args,options);
   if (ps.stdout && process.env.SLS_DEBUG){
     cli.log(ps.stdout.toString())
@@ -108,17 +111,25 @@ function bundleInstall(){
     console.log(container_id)
     if (this.options.native_bins) {
       this.cli.log("Packing the native binraries from the specified path")
-      const bin_path = path.join(this.build_path,'bin')
+      let bin_path = path.join(this.build_path,'bin')
       fs.mkdirSync(bin_path)
       this.options.native_bins.forEach(bin_to_copy => {
+        // if the last characte is a / then we assume that we want to copy the whole directory
+        if(bin_to_copy.slice(-1) === '/'){
+          bin_path = this.build_path
+        }
         ps=docker(['cp','-L', container_id+':'+bin_to_copy, bin_path],options,this.cli)
       })
     }
     if (this.options.native_libs) {
       this.cli.log("Packing the native libraries from the specified path")
-      const lib_path = path.join(this.build_path,'lib')
+      let lib_path = path.join(this.build_path,'lib')
       fs.mkdirSync(lib_path)
       this.options.native_libs.forEach(lib_to_copy => {
+        // if the last characte is a / then we assume that we want to copy the whole directory
+        if(lib_to_copy.slice(-1) === '/'){
+          lib_path = this.build_path
+        }
         ps=docker(['cp','-L', container_id+':'+lib_to_copy, lib_path],options,this.cli)
       })
     }

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -106,6 +106,14 @@ function bundleInstall(){
     ps=docker(['run','-it','--name',docker_id,'-d', docker_name,'/bin/bash'], options,this.cli)
     container_id = ps.stdout.toString().trim()
     console.log(container_id)
+    if (this.options.native_bins) {
+      this.cli.log("Packing the native binraries from the specified path")
+      const bin_path = path.join(this.build_path,'bin')
+      fs.mkdirSync(bin_path)
+      this.options.native_bins.forEach(bin_to_copy => {
+        ps=docker(['cp','-L', container_id+':'+bin_to_copy, bin_path],options,this.cli)
+      })
+    }
     if (this.options.native_libs) {
       this.cli.log("Packing the native libraries from the specified path")
       const lib_path = path.join(this.build_path,'lib')
@@ -205,6 +213,9 @@ function zipBundleFolder() {
   this.gem_folder= fs.readdirSync(path.join(this.build_path,'ruby'))[0]
   const platform = process.platform == 'win32' ? 'DOS' : 'UNIX'
   zipping_message = "Zipping the gemfiles"
+  if (this.options.native_bins) {
+    zipping_message+=" and native bins"
+  }
   if (this.options.native_libs) {
     zipping_message+=" and native libs"
   }


### PR DESCRIPTION
supports things like pdfinfo or wkpdf2html

either native_libs or native_bins entries can end in `/` doing so copies the directory contents instead of the item. This means

native_libs
  - /opt/lib/

becomes `.ruby-layer/build/lib` instead of `.ruby-layer/build/lib/lib`