### PR TITLE
Replace deprecated Docker image with AWS base image for Lambda and in…

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -55,7 +55,7 @@ function bundleInstall(){
   fs.mkdirSync(this.build_path)
   const options = {cwd : this.ruby_layer, encoding : 'utf8'}
   if (this.options.use_docker) {
-    docker_name = 'lambci/lambda:build-'+this.serverless.service.provider.runtime
+    docker_name = 'public.ecr.aws/sam/build-'+this.serverless.service.provider.runtime+':latest-x86_64'
     ps=docker(['version'], options,this.cli)
     if (ps.error && ps.error.code === 'ENOENT') {
       throw new Error('docker command not found. Please install docker https://www.docker.com/products/docker-desktop');
@@ -71,7 +71,7 @@ function bundleInstall(){
                   path.join(this.ruby_layer,'Dockerfile'))
       buildDocker = true
     }else if (this.options.docker_yums || this.options.environment) {
-      docker_steps =['FROM lambci/lambda:build-'+this.serverless.service.provider.runtime]
+      docker_steps =['FROM public.ecr.aws/sam/build-'+this.serverless.service.provider.runtime+':latest-x86_64']
       if (this.options.docker_yums) {
         this.options.docker_yums.forEach(function(package_name) {
           docker_steps.push('RUN yum install -y '+package_name)
@@ -165,7 +165,7 @@ function setBundleConfig(version, config){
 }
 
 
-function zipDir(folder_path,targetPath,zipOptions){  
+function zipDir(folder_path,targetPath,zipOptions){
   zip = new JSZip()
   return addDirtoZip(zip, folder_path)
           .then(() => {
@@ -287,6 +287,6 @@ function bundleGems()  {
           .then(bundleInstall)
           .then(zipBundleFolder)
           .then(configureLayer)
-} 
+}
 
 module.exports = { bundleGems, excludePackage };


### PR DESCRIPTION
This pull request addresses two key improvements to the codebase:

1. **Replacement of Docker Image:** I have deprecated the use of the existing Docker image and replaced it with the AWS base image for Lambda. This change ensures that we are using an up-to-date and supported base image, which reduces security risks and improves the maintainability.

https://docs.aws.amazon.com/lambda/latest/dg/ruby-package.html

3. **Ruby 3.2 Support:** - Updated images allows to use Ruby 3.2